### PR TITLE
Build at Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,3 +47,11 @@ jobs:
       # Store Debian package -- or just upload somewhere directly?
       - store_artifacts:
           path: target/debian
+
+      # Deploy artifact via Salt reactor; omit conditional for testing
+      - run:
+          name: "Deploy artifact"
+          command: |
+            export DEPLOY_CONTENT='{"CIRCLE_BUILD_NUM":"'$CIRCLE_BUILD_NUM'","CIRCLE_SHA1":"'$CIRCLE_SHA1'","CIRCLE_BRANCH":"'$CIRCLE_BRANCH'","CIRCLE_PROJECT_REPONAME":"'$CIRCLE_PROJECT_REPONAME'","CIRCLE_PROJECT_USERNAME":"'$CIRCLE_PROJECT_USERNAME'"}' ;
+            export DEPLOY_SIG="sha1=`echo -n "$DEPLOY_CONTENT" | openssl sha1 -hmac $DEPLOY_KEY | sed 's/^.* //'`" ;
+            curl -X POST "$DEPLOY_URL" --data "$DEPLOY_CONTENT" -H "Content-Type: application/json" -H "X-Circle-Signature: $DEPLOY_SIG" ;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,49 @@
+version: 2.1
+jobs:
+  build:
+    machine: true
+    working_directory: ~/project
+    steps:
+
+      # Initial setup
+      - checkout:
+          path: ~/project
+      - run:
+          name: "Info"
+          command: |
+            docker-compose --version
+            docker version
+
+      # Docker image building and caching
+      # This block shaves a minute or two off of the test runtime by using cached docker images.
+      # Otherwise we could omit this step entirely and let `docker-compose run` build what it needs to.
+      - restore_cache:
+          key: docker-images-{{ checksum "docker-compose.yml" }}
+      - run:
+          name: "Build docker images"
+          command: |
+            if test -f ~/docker-cache.tar; then
+              echo "Loading cached docker images"
+              docker load -i ~/docker-cache.tar
+            else
+              echo "Building new docker images"
+              docker-compose build
+              docker save -o ~/docker-cache.tar holiday-card
+            fi
+      - save_cache:
+          key: docker-images-{{ checksum "docker-compose.yml" }}
+          paths:
+            - "~/docker-cache.tar"
+
+      # Build
+      - run:
+          name: "Build"
+          command: |
+            docker-compose up -d
+            docker-compose exec web bash -c 'cd frontend && npm install'
+            docker-compose exec web cargo build --release
+            docker-compose exec web cargo deb
+
+      # Store Debian package -- or just upload somewhere directly?
+      - store_artifacts:
+          path: target/debian

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,13 @@ jobs:
       - store_artifacts:
           path: target/debian
 
-      # Deploy artifact via Salt reactor; omit conditional for testing
+      # Deploy artifact via Salt reactor
       - run:
           name: "Deploy artifact"
           command: |
+            if [ "$CIRCLE_PULL_REQUEST" == "" ] ;
+            then
             export DEPLOY_CONTENT='{"CIRCLE_BUILD_NUM":"'$CIRCLE_BUILD_NUM'","CIRCLE_SHA1":"'$CIRCLE_SHA1'","CIRCLE_BRANCH":"'$CIRCLE_BRANCH'","CIRCLE_PROJECT_REPONAME":"'$CIRCLE_PROJECT_REPONAME'","CIRCLE_PROJECT_USERNAME":"'$CIRCLE_PROJECT_USERNAME'"}' ;
             export DEPLOY_SIG="sha1=`echo -n "$DEPLOY_CONTENT" | openssl sha1 -hmac $DEPLOY_KEY | sed 's/^.* //'`" ;
             curl -X POST "$DEPLOY_URL" --data "$DEPLOY_CONTENT" -H "Content-Type: application/json" -H "X-Circle-Signature: $DEPLOY_SIG" ;
+            fi


### PR DESCRIPTION
If we're not using Artifactory/JFrog, packagecloud, etc., we can get the built artifact directly from Circle -- see https://circleci.com/docs/2.0/artifacts/#downloading-all-artifacts-for-a-build-on-circleci